### PR TITLE
Support for JSON-RPC notifications

### DIFF
--- a/barrister/__init__.py
+++ b/barrister/__init__.py
@@ -11,7 +11,7 @@
     :copyright: 2012 by James Cooper.
     :license: MIT, see LICENSE for more details.
 """
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 
 from barrister.runtime import contract_from_file, idgen_uuid, idgen_seq
 from barrister.runtime import RpcException, Server, Filter, HttpTransport, InProcTransport

--- a/barrister/test/idl/including-notifications.idl
+++ b/barrister/test/idl/including-notifications.idl
@@ -1,0 +1,7 @@
+interface MyInterface {
+	// This is a "notification" method
+	NotifyMe(message string)
+
+	// This is a "regular" method
+	ARegularMethod(param1 string, param2 string) bool
+}

--- a/barrister/test/parser_test.py
+++ b/barrister/test/parser_test.py
@@ -621,5 +621,15 @@ struct Blah {
         paths = file_paths(test[0], test[1])
         self.assertEquals(test[2], paths)
 
+    def test_notification_type(self):
+        idl = """interface FooService {
+    notifyThis(s string)
+}"""
+        expected = [ { "name" : "FooService", "type" : "interface", "comment" : "",
+                       "functions" : [
+                    { "name" : "notifyThis",  "comment" : "",
+                      "params" : [ { "type" : "string", "name" : "s", "is_array": False } ] } ] } ]
+        self.assertEquals(expected, parse(idl, add_meta=False))
+
 if __name__ == "__main__":
     unittest.main()

--- a/idl_parse_test.sh
+++ b/idl_parse_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # files that should parse
-okIdl=("project2.idl" "ok-service.idl")
+okIdl=("project2.idl" "ok-service.idl" "including-notifications.idl")
 
 # files that should not parse
 badIdl=("project-with-ns.idl" "broken1.idl" "invalid-service.idl" "bad-circle.idl")

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from distutils.core import setup
 
 setup(
     name='barrister',
-    version='0.1.6',
+    version='0.1.7',
     url='https://github.com/coopernurse/barrister',
     scripts=['bin/barrister'],
     packages=['barrister',],


### PR DESCRIPTION
This branch gives users the possibility to define *Notification* methods as follows:

```
interface MyInterface {
    // This is a "notification" method
    NotifyMe(message string)

    // This is a "regular" method
    ARegularMethod(param1 string, param2 string) bool
}
```

The output JSON would be:

```
[
    {
        "comment":"",
        "functions":[
            {
                "comment":"This is a \"notification\" method",
                "params":[
                    {
                        "is_array":false,
                        "type":"string",
                        "name":"message"
                    }
                ],
                "name":"NotifyMe"
            },
            {
                "comment":"This is a \"regular\" method",
                "returns":{
                    "optional":false,
                    "is_array":false,
                    "type":"bool"
                },
                "params":[
                    {
                        "is_array":false,
                        "type":"string",
                        "name":"param1"
                    },
                    {
                        "is_array":false,
                        "type":"string",
                        "name":"param2"
                    }
                ],
                "name":"ARegularMethod"
            }
        ],
        "type":"interface",
        "name":"MyInterface"
    },
    {
        "barrister_version":"0.1.7",
        "type":"meta",
        "date_generated":1424798388541,
        "checksum":"d96e24c536f3eeb202129e6b7adfe8bd"
    }
]
```

Unit and IDL tests are included.

Fix #6 

/cc @coopernurse 