### PR TITLE
Added flag to skip meta information

### DIFF
--- a/barrister/__init__.py
+++ b/barrister/__init__.py
@@ -11,7 +11,7 @@
     :copyright: 2012 by James Cooper.
     :license: MIT, see LICENSE for more details.
 """
-__version__ = '0.1.7'
+__version__ = '0.1.8'
 
 from barrister.runtime import contract_from_file, idgen_uuid, idgen_seq
 from barrister.runtime import RpcException, Server, Filter, HttpTransport, InProcTransport

--- a/bin/barrister
+++ b/bin/barrister
@@ -43,6 +43,8 @@ if __name__ == "__main__":
     parser.add_option("-j", "--json", dest="json",
                       default=None, type="string",
                       help="File to write contract JSON to (defaults to STDOUT)")
+    parser.add_option("-n", "--nometa", dest="add_meta", action="store_false", default=True,
+                      help="Do not include meta information in the contract JSON")
     parser.add_option("-v", "--version", dest="version",
                       default=False, action="store_true",
                       help="Print version")
@@ -53,12 +55,12 @@ if __name__ == "__main__":
         sys.exit(0)
 
     if options.stdin:
-        parsed = parse(sys.stdin.read())
+        parsed = parse(sys.stdin.read(), add_meta=options.add_meta)
     elif len(args) < 1:
         parser.error("Incorrect number of args")
     else:
         f = open(args[0])
-        parsed = parse(f, args[0])
+        parsed = parse(f, args[0], add_meta=options.add_meta)
         f.close()
 
     if options.docco:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from distutils.core import setup
 
 setup(
     name='barrister',
-    version='0.1.7',
+    version='0.1.8',
     url='https://github.com/coopernurse/barrister',
     scripts=['bin/barrister'],
     packages=['barrister',],


### PR DESCRIPTION
Quick solution proposal for #12 
Adding `-n` or `--nometa` flag would not add the meta information to the generated contract JSON.