### PR TITLE
Upgrade to python3.

### DIFF
--- a/barrister/docco.py
+++ b/barrister/docco.py
@@ -220,11 +220,11 @@ def format_type(t, includeOptional=True):
         The type as a dict. Keys: 'type', 'is_array'
     """
     s = ""
-    if t.has_key('is_array') and t['is_array']:
+    if 'is_array' in t and t['is_array']:
         s = "[]%s" % t['type']
     else:
         s = t['type']
-    if includeOptional and t.has_key('optional') and t['optional'] == True:
+    if includeOptional and 'optional' in t and t['optional'] == True:
         s += " [optional]"
     return s
 
@@ -338,12 +338,12 @@ def parse_struct(s):
 
     i = 0
     for v in s["fields"]:
-        if v.has_key('comment') and v['comment']:
+        if 'comment' in v and v['comment']:
             if i > 0: code += "\n"
             for line in v['comment'].split("\n"):
                 code += '    <span class="c1">// %s</span>\n' % line
         opt = ""
-        if v.has_key('optional') and v['optional'] == True:
+        if 'optional' in v and v['optional'] == True:
           opt = " [optional]"
         code += formatstr % (string.ljust(v['name'], namelen), string.ljust(format_type(v, includeOptional=False), typelen), opt)
         i += 1
@@ -370,7 +370,7 @@ def parse_interface(iface):
             else: func_code += ", "
             func_code += '<span class="na">%s</span> <span class="kt">%s</span>' % (p['name'], format_type(p))
         func_code += ') <span class="kt">%s</span>\n' % format_type(v['returns'])
-        if v.has_key('comment') and v['comment']:
+        if 'comment' in v and v['comment']:
             if code:
                 sections.append(to_section(docs, code))
             docs = v['comment']
@@ -448,4 +448,4 @@ if __name__ == "__main__":
         f.close()
 
     idl_parsed = json.loads(j)
-    print docco_html(options.title, idl_parsed)
+    print(docco_html(options.title, idl_parsed))

--- a/barrister/graphviz.py
+++ b/barrister/graphviz.py
@@ -15,13 +15,13 @@
 
 def type_str(type_dict):
     s = type_dict['type']
-    if type_dict.has_key('is_array') and type_dict['is_array']:
+    if 'is_array' in type_dict and type_dict['is_array']:
         s = s + "[]"
     return s
 
 def struct_dot(struct):
     extends = ""
-    if struct.has_key("extends") and struct["extends"]:
+    if "extends" in struct and struct["extends"]:
         extends = "%s -> %s" % (struct["name"], struct["extends"])
         
     label = "%s|" % struct["name"]
@@ -84,7 +84,7 @@ def to_dotfile(parsed_idl):
         
         """
     for entity in parsed_idl:
-        if entity.has_key("type"):
+        if "type" in entity:
             t = entity["type"]
             if t == "struct":
                 dot += "\n" + struct_dot(entity)

--- a/barrister/test/parser_test.py
+++ b/barrister/test/parser_test.py
@@ -39,7 +39,7 @@ struct Person {
                      { "type" : "struct", "name" : "Person", "extends" : "",
                        "comment" : "this is a person", "fields" : [
                     field("age", "int") ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_parse_struct(self):
         idl = """struct Person {
@@ -50,7 +50,7 @@ age int
                        "type" : "struct", 
                        "comment" : "", "extends" : "",
                        "fields" : [ field("email", "string"), field("age", "int") ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_parse_multiple(self):
         idl = """struct Person { email string } 
@@ -63,7 +63,7 @@ struct Animal { furry bool }"""
                        "type" : "struct", 
                        "comment" : "", "extends" : "",
                        "fields" : [ field("furry", "bool") ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_parse_enum(self):
         idl = """enum Status { success fail
@@ -72,7 +72,7 @@ invalid }"""
                        "values" : [ { "value" : "success", "comment" : "" },
                                     { "value" : "fail", "comment" : "" },
                                     { "value" : "invalid", "comment" : "" } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_parse_interface(self):
         idl = """interface MyService {
@@ -91,7 +91,7 @@ invalid }"""
                     { "name" : "login", "comment" : "",
                       "returns" : ret_field("LoginResponse"), "params" : [
                             { "type" : "LoginRequest", "name" : "req", "is_array": False } ] } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False, validate=False))
+        self.assertEqual(expected, parse(idl, add_meta=False, validate=False))
 
     def test_invalid_struct(self):
         idl = """struct foo { """
@@ -100,7 +100,7 @@ invalid }"""
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 1, "message" : "Unexpected end of file" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
 
     def test_missing_name(self):
         idls = [ "struct  {", "enum {", "interface { " ]
@@ -110,7 +110,7 @@ invalid }"""
                 self.fail("should have thrown exception")
             except IdlParseException as e:
                 expected = [ { "line": 1, "message" : "Missing identifier" } ]
-                self.assertEquals(expected, e.errors)
+                self.assertEqual(expected, e.errors)
 
     def test_enum_comments(self):
         idl = """enum Status {
@@ -119,7 +119,7 @@ invalid }"""
         expected = [ { "name" : "Status", "type" : "enum", "comment" : "",
                        "values" : [ { "comment" : "Request successful",
                                       "value": "success" } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))        
+        self.assertEqual(expected, parse(idl, add_meta=False))        
 
     def test_array_type(self):
         idl = """struct Animal  {
@@ -127,7 +127,7 @@ invalid }"""
         expected = [ { "name" : "Animal", "type" : "struct", "comment" : "",
                        "extends" : "",
                  "fields" : [ field("friend_names", "string", "", True) ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_array_return_type(self):
         idl = """interface FooService {
@@ -138,7 +138,7 @@ invalid }"""
                     { "name" : "repeat",  "comment" : "",
                       "returns" : ret_field("string", True),
                       "params" : [ { "type" : "string", "name" : "s", "is_array": False } ] } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_struct_comments(self):
         idl = """struct Animal   {
@@ -147,7 +147,7 @@ invalid }"""
         expected = [ { "name" : "Animal", "type" : "struct", "comment" : "",
                        "extends" : "",
                        "fields" : [ field("color", "string", "fur color") ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))        
+        self.assertEqual(expected, parse(idl, add_meta=False))        
 
     def test_function_comments(self):
         idl = """interface FooService {
@@ -163,7 +163,7 @@ invalid }"""
                       "params" : [ 
                             { "type" : "int", "name" : "a", "is_array": False },
                             { "type" : "int", "name" : "b", "is_array": True } ] } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))        
+        self.assertEqual(expected, parse(idl, add_meta=False))        
 
     def test_interface_comments(self):
         idl = """// FooService is a..
@@ -177,7 +177,7 @@ interface FooService {
                     { "name" : "blah99", "returns" : ret_field("blah_Response"),
                       "comment" : "", "params" : [ ] }
                     ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False, validate=False))
+        self.assertEqual(expected, parse(idl, add_meta=False, validate=False))
         
 
     def test_extends_struct(self):
@@ -195,7 +195,7 @@ struct Cat extends Animal {
                      { "name" : "Cat", "type" : "struct", 
                        "extends" : "Animal", "comment" : "",
                        "fields" : [ field("purr_volume", "int") ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_no_dupe_types(self):
         idl = """struct Animal {
@@ -221,7 +221,7 @@ interface Blarg {
             expected = [ { "line": 4, "message" : "type Animal already defined" },
                          { "line": 10, "message" : "type Foo already defined" },
                          { "line": 14, "message" : "type Blarg already defined" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
 
     def test_no_cycles_for_required_fields(self):
         idl = """struct Animal {
@@ -236,7 +236,7 @@ struct Location {
         except IdlParseException as e:
             expected = [ { "line": 3, "message" : "cycle detected in struct: Animal" },
                          { "line": 6, "message" : "cycle detected in struct: Location" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
 
     def test_slice_cycle_ok(self):
         idl = """struct Animal {
@@ -269,7 +269,7 @@ struct Location {
         except IdlParseException as e:
           expected = [ { "line": 3, "message" : "cycle detected in struct: Animal" },
                        { "line": 6, "message" : "cycle detected in struct: Location" } ]
-          self.assertEquals(expected, e.errors)
+          self.assertEqual(expected, e.errors)
 
     def test_no_mutual_extends(self):
         idl = """struct Animal extends Location {
@@ -285,7 +285,7 @@ struct Location extends Animal {
         except IdlParseException as e:
           expected = [ { "line": 3, "message" : "cycle detected in struct: Animal" },
                        { "line": 6, "message" : "cycle detected in struct: Location" } ]
-          self.assertEquals(expected, e.errors)
+          self.assertEqual(expected, e.errors)
 
     def test_cycle_detection(self):
         idl = """struct Book {
@@ -309,7 +309,7 @@ interface FooService {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 2, "message" : "interface FooService cannot be used as a type" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_types_exist(self):
         idl = """struct Animal {
@@ -329,7 +329,7 @@ struct Blarg extends Foo {
                          { "line": 5, "message" : "undefined type: Cat" },
                          { "line": 5, "message" : "undefined type: Saying" },
                          { "line": 7, "message" : "Blarg extends unknown type Foo" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
             
     def test_ident_can_start_with_underscores(self):
         idl = """struct Animal { 
@@ -340,7 +340,7 @@ struct Blarg extends Foo {
                        "extends" : "", "comment" : "",
                        "fields" : [ field("_id", "int"), 
                                     field("_name", "string") ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_cant_override_parent_field(self):
         idl = """struct Animal {
@@ -359,7 +359,7 @@ struct Manx extends Cat {
         except IdlParseException as e:
             expected = [ { "line": 6, "message" : "Cat cannot redefine parent field color" },
                          { "line": 9, "message" : "Manx cannot redefine parent field gender" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
 
     def test_struct_cant_extend_enum(self):
         idl = """enum Status { foo }
@@ -371,7 +371,7 @@ struct Animal extends Status {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 2, "message" : "Animal cannot extend enum Status" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_struct_cant_extend_native_type(self):
         idl = """struct Animal extends float {
@@ -382,7 +382,7 @@ struct Animal extends Status {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 1, "message" : "Animal cannot extend float" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_struct_must_have_fields(self):
         idl = "struct Animal { }"
@@ -391,7 +391,7 @@ struct Animal extends Status {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 1, "message" : "Animal must have at least one field" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_interface_must_have_funcs(self):
         idl = "interface FooService { }"
@@ -400,7 +400,7 @@ struct Animal extends Status {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 1, "message" : "FooService must have at least one function" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_enum_must_have_values(self):
         idl = "enum Status { }"
@@ -409,7 +409,7 @@ struct Animal extends Status {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 1, "message" : "Status must have at least one value" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_cycle_detection_for_interfaces(self):
         idl = """struct BaseResponse {
@@ -436,7 +436,7 @@ interface FooService {
         except IdlParseException as e:
             expected = [ { "line": 5, "message" : "interface BlargService cannot be used as a type" },
                          { "line": 6, "message" : "interface BlargService cannot be used as a type" } ]
-            self.assertEquals(expected, e.errors)        
+            self.assertEqual(expected, e.errors)        
 
     def test_optional_struct_field(self):
         idl = """struct Person {
@@ -447,7 +447,7 @@ interface FooService {
                        "extends" : "", "comment" : "",
                        "fields" : [ field("firstName", "string"), 
                                     field("email", "string", optional=True) ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_optional_return_type(self):
         idl = """interface FooService {
@@ -457,7 +457,7 @@ interface FooService {
                        "functions" : 
                        [ { "name" : "sayHi", "comment" : "", "params" : [ ],
                            "returns" : ret_field("string", optional=True) } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
     def test_prefix_namespace_if_present(self):
       idl = """
@@ -509,7 +509,7 @@ interface FooService {
                           { "comment" : "", "value": "DESC" }
                       ] }
       ]
-      self.assertEquals(expected, parse(idl, validate=False, add_meta=False))
+      self.assertEqual(expected, parse(idl, validate=False, add_meta=False))
 
     def test_cannot_namespace_interfaces(self):
         idl = """namespace foo
@@ -523,7 +523,7 @@ interface FooService {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 3, "message" : "namespace cannot be used in files with interfaces" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
 
     def test_cannot_redefine_namespace(self):
         idl = """namespace foo
@@ -534,7 +534,7 @@ namespace bar
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 2, "message" : "Cannot redeclare namespace" } ]
-            self.assertEquals(expected, e.errors)
+            self.assertEqual(expected, e.errors)
 
     def test_namespace_must_preceed_elems(self):
         idl = """enum Status { 
@@ -553,7 +553,7 @@ struct Blah {
             self.fail("should have thrown exception")
         except IdlParseException as e:
             expected = [ { "line": 6, "message" : "namespace must preceed all struct/enum/interface definitions" } ]
-            self.assertEquals(expected, e.errors)  
+            self.assertEqual(expected, e.errors)  
 
     def test_add_meta(self):
         idl = """interface FooService {
@@ -582,7 +582,7 @@ struct Blah {
             if first_checksum == None:
                 first_checksum = checksum
             else:
-                self.assertEquals(first_checksum, checksum)
+                self.assertEqual(first_checksum, checksum)
 
         base3 = "enum Y {\ndog2\ncat\n}\nstruct Z {\n a int }\n"
         base4 = "enum Y {\ndog\ncat\n}\nstruct Z {\n a float }\n"
@@ -594,7 +594,7 @@ struct Blah {
         for idl in different:
             parsed = parse(idl, add_meta=True)
             meta = parsed[-1]
-            self.assertNotEquals(first_checksum, meta["checksum"])
+            self.assertNotEqual(first_checksum, meta["checksum"])
 
     def test_file_paths(self):
       # [0] = relative filename
@@ -609,7 +609,7 @@ struct Blah {
       ]
       for test in tests:
         paths = file_paths(test[0], test[1])
-        self.assertEquals(test[2], paths)
+        self.assertEqual(test[2], paths)
 
       # remove BARRISTER_PATH and re-test
       del os.environ["BARRISTER_PATH"]
@@ -619,7 +619,7 @@ struct Blah {
       ]
       for test in tests:
         paths = file_paths(test[0], test[1])
-        self.assertEquals(test[2], paths)
+        self.assertEqual(test[2], paths)
 
     def test_notification_type(self):
         idl = """interface FooService {
@@ -629,7 +629,7 @@ struct Blah {
                        "functions" : [
                     { "name" : "notifyThis",  "comment" : "",
                       "params" : [ { "type" : "string", "name" : "s", "is_array": False } ] } ] } ]
-        self.assertEquals(expected, parse(idl, add_meta=False))
+        self.assertEqual(expected, parse(idl, add_meta=False))
 
 if __name__ == "__main__":
     unittest.main()

--- a/barrister/test/runtime_test.py
+++ b/barrister/test/runtime_test.py
@@ -66,7 +66,7 @@ interface UserService {
 """
 
 def newUser(userId="abc123", email=None):
-    return { "userId" : userId, "password" : u"pw", "email" : email,
+    return { "userId" : userId, "password" : "pw", "email" : email,
       "emailVerified" : False, "dateCreated" : 1, "age" : 3.3 }
 
 def now_millis():
@@ -133,10 +133,10 @@ class RuntimeTest(unittest.TestCase):
         resp = svc.create(user)
         self.assertTrue(resp["userId"])
         user2 = svc.get(resp["userId"])["user"]
-        self.assertEquals(user["email"], user2["email"])
+        self.assertEqual(user["email"], user2["email"])
         self.assertTrue(user["dateCreated"] > 0)
-        self.assertEquals("ok", svc.changePassword("123", "oldpw", "newpw")["status"])
-        self.assertEquals(1, svc.countUsers()["count"])
+        self.assertEqual("ok", svc.changePassword("123", "oldpw", "newpw")["status"])
+        self.assertEqual(1, svc.countUsers()["count"])
         svc.getAll([])
 
     def test_invalid_req(self):
@@ -193,10 +193,10 @@ class RuntimeTest(unittest.TestCase):
         batch.UserService.create(newUser(userId="2", email="foo@bar.com"))
         batch.UserService.countUsers()
         results = batch.send()
-        self.assertEquals(3, len(results))
-        self.assertEquals(results[0].result["message"], "user created")
-        self.assertEquals(results[1].result["message"], "user created")
-        self.assertEquals(2, results[2].result["count"])
+        self.assertEqual(3, len(results))
+        self.assertEqual(results[0].result["message"], "user created")
+        self.assertEqual(results[1].result["message"], "user created")
+        self.assertEqual(2, results[2].result["count"])
 
     def _test_bench(self):
         start = time.time()
@@ -206,7 +206,7 @@ class RuntimeTest(unittest.TestCase):
             self.client.UserService.countUsers()
             num += 1
         elapsed = time.time() - start
-        print "test_bench: num=%d microsec/op=%d" % (num, (elapsed*1000000)/num)
+        print("test_bench: num=%d microsec/op=%d" % (num, (elapsed*1000000)/num))
 
         start = time.time()
         stop = start+1
@@ -215,7 +215,7 @@ class RuntimeTest(unittest.TestCase):
             self.client.UserService.create(newUser())
             num += 1
         elapsed = time.time() - start
-        print "test_bench: num=%d microsec/op=%d" % (num, (elapsed*1000000)/num)
+        print("test_bench: num=%d microsec/op=%d" % (num, (elapsed*1000000)/num))
 
 if __name__ == "__main__":
     unittest.main()

--- a/bin/barrister
+++ b/bin/barrister
@@ -18,10 +18,10 @@ def wrap_exec(name, cmd):
     out, err = proc.communicate()
     for line in out.split("\n"):
         if line:
-            print "[%s out] %s" % (name, line)
+            print("[%s out] %s" % (name, line))
     for line in err.split("\n"):
         if line:
-            print "[%s err] %s" % (name, line)
+            print("[%s err] %s" % (name, line))
     return proc.poll()
 
 if __name__ == "__main__":
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args()
 
     if options.version:
-        print "barrister %s" % __version__
+        print("barrister %s" % __version__)
         sys.exit(0)
 
     if options.stdin:
@@ -79,8 +79,8 @@ if __name__ == "__main__":
             cmd.extend(options.dotargs.split(" "))
         cmd.append(fname)
         if wrap_exec("graphviz", cmd) != 0:
-            print "Error running Graphviz dot. Is it installed?"
-            print "Command: %s" % str(cmd)
+            print("Error running Graphviz dot. Is it installed?")
+            print("Command: %s" % str(cmd))
             os.unlink(fname)
             sys.exit(1)
         os.unlink(fname)
@@ -90,4 +90,4 @@ if __name__ == "__main__":
         f.write(json.dumps(parsed))
         f.close()
     else:
-        print json.dumps(parsed)
+        print(json.dumps(parsed))

--- a/conform/client.py
+++ b/conform/client.py
@@ -26,7 +26,7 @@ def get_and_log_result(iface, func, params, result, error):
     if error != None:
         status = "rpcerr"
         resp = error.code
-        print "RPCERR: %s" % error.msg
+        print("RPCERR: %s" % error.msg)
 
     out.write("%s|%s|%s|%s|%s\n" % (iface, func, params, status, json.dumps(resp)))
     out.flush()

--- a/conform/conform_test.py
+++ b/conform/conform_test.py
@@ -5,7 +5,7 @@ import time
 import threading
 import unittest
 import os
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 import codecs
 try:
     import json
@@ -15,7 +15,7 @@ except:
 # Barrister conformance test runner
 
 def env_get(envkey, defval):
-    if os.environ.has_key(envkey):
+    if envkey in os.environ:
         return os.environ[envkey]
     else:
         return defval
@@ -57,11 +57,11 @@ clients = [
     [ "go-client", ["%s/conform/client" % barrister_go ] ]
 ]
 
-verbose = os.environ.has_key('CONFORM_VERBOSE')
+verbose = 'CONFORM_VERBOSE' in os.environ
 
 def log(msg):
     if verbose:
-        print msg.strip()
+        print(msg.strip())
 
 class Runner(threading.Thread):
 
@@ -138,16 +138,16 @@ class ConformTest(unittest.TestCase):
         invalid = [ "{", "[", "--" ]
         for s in invalid:
             data = """{ "jsonrpc": "2.0", "method": "foo", "params": %s }""" % s
-            req = urllib2.Request("http://localhost:9233/", data, headers)
-            f = urllib2.urlopen(req)
+            req = urllib.request.Request("http://localhost:9233/", data, headers)
+            f = urllib.request.urlopen(req)
             json_resp = f.read()
             f.close()
             try:
                 resp = json.loads(json_resp)
             except:
-                print "Unable to parse: %s" % json_resp
+                print("Unable to parse: %s" % json_resp)
                 raise
-            self.assertEquals(resp["error"]["code"], -32700, "Fail using invalid JSON: %s" % s)
+            self.assertEqual(resp["error"]["code"], -32700, "Fail using invalid JSON: %s" % s)
 
     def _test_server(self, sleep_time, s_name, s_cmd, cwd=None):
         errs = [ ]
@@ -167,7 +167,7 @@ class ConformTest(unittest.TestCase):
             self._test_invalid_json()
 
             for c_name, c_cmd in clients:
-                print "Testing client '%s' vs server '%s'" % (c_name, s_name)
+                print("Testing client '%s' vs server '%s'" % (c_name, s_name))
                 outfile = "%s-to-%s.out" % (c_name, s_name)
                 c_cmd_cpy = c_cmd[:]
                 c_cmd_cpy.extend([infile, outfile])
@@ -214,5 +214,5 @@ class ConformTest(unittest.TestCase):
             
 if __name__ == "__main__":
     if not verbose:
-        print "Verbose output disabled. To enable: export CONFORM_VERBOSE=1"
+        print("Verbose output disabled. To enable: export CONFORM_VERBOSE=1")
     unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.12.2
 Markdown==2.1.1
-plex==2.0.0dev
+plex3==2.0.0dev

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -6,7 +6,7 @@ export PYTHONPATH=`pwd`
 
 # regular unit tests
 # use xargs instead of -exec so that we get exit code propegation
-find ./barrister/test -name "*_test.py" -print | xargs -n1 python2
+find ./barrister/test -name "*_test.py" -print | xargs -n1 python3
 
 # run script to test parsing various IDL files
 ./idl_parse_test.sh
@@ -20,4 +20,4 @@ go build server.go
 cd -
 
 # conformance test suite
-cd conform; rm -f *.out; python2 conform_test.py
+cd conform; rm -f *.out; python3 conform_test.py

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=__doc__,
     install_requires=[
         'Markdown',
-        'plex'
+        'plex3'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This PR will upgrade barrister to support python3.

Notes: 
- ran 2to3 to convert to python3
- only interesting bit was the plex library was not supported, I found someone had created a plex3 version that seemed to be compatible.  It hadn't been touched in 12 years though.  Could look at other options too, per your comments in that other pull request, but this seemed to work out of the box.
- tested locally using our application
- ran the test suite, unit tests pass, I don't have the "go" setup though
`./run_tests.sh: 15: cd: can't cd to /src/github.com/coopernurse/barrister-go/conform`