### PR TITLE
python v3 upgrade - setup for clean install

### DIFF
--- a/barrister/parser.py
+++ b/barrister/parser.py
@@ -13,8 +13,8 @@ import time
 import copy
 import operator
 import io
-from plex3 import Scanner, Lexicon, Str, State, IGNORE
-from plex3 import Begin, Any, AnyBut, AnyChar, Range, Rep
+from plex import Scanner, Lexicon, Str, State, IGNORE
+from plex import Begin, Any, AnyBut, AnyChar, Range, Rep
 try:
     import json
 except:

--- a/barrister/parser.py
+++ b/barrister/parser.py
@@ -13,8 +13,8 @@ import time
 import copy
 import operator
 import io
-from plex import Scanner, Lexicon, Str, State, IGNORE
-from plex import Begin, Any, AnyBut, AnyChar, Range, Rep
+from plex3 import Scanner, Lexicon, Str, State, IGNORE
+from plex3 import Begin, Any, AnyBut, AnyChar, Range, Rep
 try:
     import json
 except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.12.2
-Markdown==3.7
-git+https://github.com/uogbuji/plex3.git#egg=plex3
+Markdown==2.1.1
+plex3==2.0.0dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Flask==0.12.2
-Markdown==2.1.1
-plex3==2.0.0dev
+Markdown==3.7
+git+https://github.com/uogbuji/plex3.git#egg=plex3


### PR DESCRIPTION
This PR should allow for a clean install by doing the following:
- install plex3 directly from git repo
- upgrade markdown, older version not supported in latest python

You should be able to install all the deps on a virtual environment.  Would like to look at rewriting parser with a library that is maintained like the one you suggested, but won't have time to do so.