### PR TITLE
reference plex3 repo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=__doc__,
     install_requires=[
         'Markdown',
-        'plex3'
+        'plex3 @ git+https://github.com/uogbuji/plex3.git'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
It looks like fetching dependencies from requirements.txt is separate from setup.py.  Updating the latter to refer to the git repository for plex3 as well, this should get the local install working using:
`pip install .`
in the barrister directory