### PR TITLE
use ljust on string object

### DIFF
--- a/barrister/docco.py
+++ b/barrister/docco.py
@@ -345,7 +345,7 @@ def parse_struct(s):
         opt = ""
         if 'optional' in v and v['optional'] == True:
           opt = " [optional]"
-        code += formatstr % (string.ljust(v['name'], namelen), string.ljust(format_type(v, includeOptional=False), typelen), opt)
+        code += formatstr % (v['name'].ljust(namelen), format_type(v, includeOptional=False).ljust(typelen), opt)
         i += 1
     code += "}"
 


### PR DESCRIPTION
We need to use ljust on the string object itself not from the string module.